### PR TITLE
Adjust PHP version constraint in composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "http://github.com/chrometoasters/silverstripe-metadescription-fallback/issues"
     },
     "require": {
-        "php": "^5.4",
+        "php": ">= 5.4, <7.2",
         "silverstripe/cms": "^3.2"
     }
 }


### PR DESCRIPTION
Allow PHP versions 7.0.x and 7.1.x.