### PR TITLE
Meta description output formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor
+.project
+.settings
+.idea
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
     "homepage": "http://github.com/chrometoasters/silverstripe-metadescription-fallback",
     "authors": [
         {
+            "name": "Doug McKechie",
+            "email": "doug.mckechie@chrometoaster.com"
+        },
+        {
             "name": "Michal Kleiner",
             "email": "michal.kleiner@chrometoaster.com"
         }
@@ -15,7 +19,6 @@
         "issues": "http://github.com/chrometoasters/silverstripe-metadescription-fallback/issues"
     },
     "require": {
-        "php": ">= 5.6, <7.2",
         "silverstripe/cms": "^4.0"
     }
 }

--- a/src/extensions/MetaDescriptionFallbackExtension.php
+++ b/src/extensions/MetaDescriptionFallbackExtension.php
@@ -93,7 +93,10 @@ class MetaDescriptionFallbackExtension extends DataExtension
             }
         }
 
-        return strip_tags($metaDescription);
+        // add a space to closing </p> to prevent bunching, strip all tags and replace multiple spaces with a single one
+        $metaDescription = preg_replace('/\s+/', ' ', strip_tags(trim(str_replace('</p>', '</p> ', $metaDescription))));
+
+        return $metaDescription;
     }
 
 


### PR DESCRIPTION
Tweak the output of the function to preserve spaces after removing html tags.