### PR TITLE
Ensure regex special chars are escaped

### DIFF
--- a/src/extensions/MetaDescriptionFallbackExtension.php
+++ b/src/extensions/MetaDescriptionFallbackExtension.php
@@ -112,7 +112,7 @@ class MetaDescriptionFallbackExtension extends DataExtension
         $metaDescription = $this->getGeneralMetaDescription();
 
         if (!empty($metaDescription)) {
-            $tag = sprintf('<meta name="description" content="%s" />', $metaDescription);
+            $tag = sprintf('<meta name="description" content="%s" />', preg_replace('/\$/', '\\\$', $metaDescription));
             $replacePattern = '/<meta.*?name="description".*?\/>/sU';
 
             // replace if present, append otherwise

--- a/src/extensions/MetaDescriptionFallbackExtension.php
+++ b/src/extensions/MetaDescriptionFallbackExtension.php
@@ -112,12 +112,12 @@ class MetaDescriptionFallbackExtension extends DataExtension
         $metaDescription = $this->getGeneralMetaDescription();
 
         if (!empty($metaDescription)) {
-            $tag = sprintf('<meta name="description" content="%s" />', preg_replace('/\$/', '\\\$', $metaDescription));
-            $replacePattern = '/<meta.*?name="description".*?\/>/sU';
+            $tag = sprintf('<meta name="description" content="%s">', $metaDescription);
+            $replacePattern = '/<meta.*?name="description".*?>/U';
 
             // replace if present, append otherwise
             if (preg_match($replacePattern, $tags)) {
-                $tags = preg_replace($replacePattern, $tag, $tags, 1);
+                $tags = preg_replace($replacePattern, preg_replace('/\$/', '\\\$', $tag), $tags, 1);
             } else {
                 $tags .= $tag;
             }


### PR DESCRIPTION
Usage of `$` replaced with an empty value. For example `The ... Func announced $500,00 in ....`

