### PR TITLE
Replace deprecated get_class call with static::class

### DIFF
--- a/src/extensions/MetaDescriptionFallbackExtension.php
+++ b/src/extensions/MetaDescriptionFallbackExtension.php
@@ -67,7 +67,7 @@ class MetaDescriptionFallbackExtension extends DataExtension
         if (empty($metaDescription)) {
 
             // configured fallback fields and/or methods
-            $fallbackFields = Config::inst()->get(get_class(), 'fallback_fields');
+            $fallbackFields = Config::inst()->get(static::class, 'fallback_fields');
 
             if ($fallbackFields && is_array($fallbackFields) && count($fallbackFields)) {
                 foreach ($fallbackFields as $fb) {


### PR DESCRIPTION
PHP 8.3 deprecated `get_class` call without parameters.